### PR TITLE
fix(dockerfile)

### DIFF
--- a/dev-ops/docker/containers/php7/Dockerfile
+++ b/dev-ops/docker/containers/php7/Dockerfile
@@ -11,7 +11,7 @@ COPY createuser.sh /addExternalUser
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN mkdir -p /usr/share/man/man1
 
-RUN apt-get update && apt-get install -y ant mysql-client
+RUN apt-get update && apt-get install -y ant default-mysql-client
 
 RUN chmod +x /usr/local/bin/wait-for-it.sh \
 && ln -s /app/psh.phar /bin/psh

--- a/dev-ops/docker/containers/php7/Dockerfile
+++ b/dev-ops/docker/containers/php7/Dockerfile
@@ -1,5 +1,7 @@
 FROM webdevops/php-apache-dev:7.2
 
+# https://dockerfile.readthedocs.io/en/latest/content/DockerImages/dockerfiles/php-apache-dev.html#composer
+ENV COMPOSER_VERSION=1
 ENV COMPOSER_HOME=/.composer
 ENV WEB_DOCUMENT_ROOT=/var/www/shopware/shopware
 


### PR DESCRIPTION
add mysql client fix, there is no mysql-client anymore, it's called default ...*

just merge it and we have a working alternative compared to the main repo without always having to check what was wrong ... x) I  can then delete the fork from my acc. again ^^


~ https://stackoverflow.com/questions/57048428/e-package-mysql-client-has-no-installation-candidate-in-php-fpm-image-build-u